### PR TITLE
Remove empty tasks

### DIFF
--- a/.github/ISSUE_TEMPLATE/requirement.md
+++ b/.github/ISSUE_TEMPLATE/requirement.md
@@ -26,4 +26,4 @@ labels: "requirement"
 
 ## Taken
 
-- [ ] --
+--


### PR DESCRIPTION
Removes the checkbox from the template. Prevents "1 task remaining" from showing up on tickets when no tasks are defined.